### PR TITLE
Allow variables to have multiple ranges across different data objects

### DIFF
--- a/ABRSchema_0-2-0.json
+++ b/ABRSchema_0-2-0.json
@@ -84,7 +84,7 @@
             "properties": {
                 "scalarRanges": {
                     "type": "object",
-                    "description": "Ranges for scalar variables. Custom, per-keydata ranges can be specified as well, by adding KeyData -> ScalarVariables to this dictionary",
+                    "description": "Ranges for scalar variables. This object contains the global, systemwide definitions for var ranges.",
                     "$comment": "Must explicitly specify DataPath key here",
                     "patternProperties": { 
                         "^([^/]+)\/([^/]+)\/(ScalarVar)\/([^/]+)$": {
@@ -95,7 +95,14 @@
                                 "min": { "type": "number" },
                                 "max": { "type": "number" }
                             }
-                        },
+                        }
+                    }
+                },
+                "specificScalarRanges": {
+                    "type": "object",
+                    "description": "Ranges for scalar variables. Custom, per-keydata ranges are specified here.",
+                    "$comment": "Must explicitly specify DataPath key here",
+                    "patternProperties": { 
                         "^([^/]+)\/([^/]+)\/(KeyData)\/([^/]+)$": {
                             "type": "object",
                             "description": "Definition of minimum / maximum that applies to this key data object only",

--- a/ABRSchema_0-2-0.json
+++ b/ABRSchema_0-2-0.json
@@ -86,11 +86,17 @@
                     "type": "object",
                     "description": "Ranges for scalar variables",
                     "$comment": "Unfortunately must explicitly specify DataPath key here",
+                    "required": ["min", "max"],
                     "patternProperties": { 
                         "^([^/]+)\/([^/]+)\/(ScalarVar)\/([^/]+)$": {
                             "type": "object",
                             "description": "Minimum and maximum for a scalar variable",
                             "properties": {
+                                "keyDataPath": {
+                                    "type": "string",
+                                    "description": "To allow for multiple ranges on a variable that is used in multiple places, we can add an additional specifier here to tie a particular range to a key data object.",
+                                    "pattern": "^([^/]+)\/([^/]+)\/(KeyData)\/([^/]+)$"
+                                },
                                 "min": { "type": "number" },
                                 "max": { "type": "number" }
                             }

--- a/ABRSchema_0-2-0.json
+++ b/ABRSchema_0-2-0.json
@@ -84,21 +84,28 @@
             "properties": {
                 "scalarRanges": {
                     "type": "object",
-                    "description": "Ranges for scalar variables",
-                    "$comment": "Unfortunately must explicitly specify DataPath key here",
+                    "description": "Ranges for scalar variables. Custom, per-keydata ranges can be specified as well, by adding KeyData -> ScalarVariables to this dictionary",
+                    "$comment": "Must explicitly specify DataPath key here",
                     "patternProperties": { 
                         "^([^/]+)\/([^/]+)\/(ScalarVar)\/([^/]+)$": {
                             "type": "object",
-                            "description": "Minimum and maximum for a scalar variable",
+                            "description": "Systemwide definition for minimum / maximum of a variable",
                             "required": ["min", "max"],
                             "properties": {
-                                "keyDataPath": {
-                                    "type": "string",
-                                    "description": "To allow for multiple ranges on a variable that is used in multiple places, we can add an additional specifier here to tie a particular range to a key data object.",
-                                    "pattern": "^([^/]+)\/([^/]+)\/(KeyData)\/([^/]+)$"
-                                },
                                 "min": { "type": "number" },
                                 "max": { "type": "number" }
+                            }
+                        },
+                        "^([^/]+)\/([^/]+)\/(KeyData)\/([^/]+)$": {
+                            "type": "object",
+                            "description": "Definition of minimum / maximum that applies to this key data object only",
+                            "patternProperties": {
+                                "^([^/]+)\/([^/]+)\/(ScalarVar)\/([^/]+)$": {
+                                    "type": "object",
+                                    "required": ["min", "max"],
+                                        "min": { "type": "number" },
+                                        "max": { "type": "number" }
+                                }
                             }
                         }
                     }

--- a/ABRSchema_0-2-0.json
+++ b/ABRSchema_0-2-0.json
@@ -86,11 +86,11 @@
                     "type": "object",
                     "description": "Ranges for scalar variables",
                     "$comment": "Unfortunately must explicitly specify DataPath key here",
-                    "required": ["min", "max"],
                     "patternProperties": { 
                         "^([^/]+)\/([^/]+)\/(ScalarVar)\/([^/]+)$": {
                             "type": "object",
                             "description": "Minimum and maximum for a scalar variable",
+                            "required": ["min", "max"],
                             "properties": {
                                 "keyDataPath": {
                                     "type": "string",


### PR DESCRIPTION
This PR allows multiple simultaneous data ranges to be represented for a single variable. See this PR's companions for implementations on the C# and JavaScript sides:

- https://github.umn.edu/ivlab-cs/ABREngine-UnityPackage/pull/15
- https://github.umn.edu/ivlab-cs/abr_server/pull/12