### PR TITLE
Modify Bounds representation in schema

### DIFF
--- a/ABRSchema_0-2-0.json
+++ b/ABRSchema_0-2-0.json
@@ -451,10 +451,10 @@
             },
             "Bounds": {
                 "type": "object",
-                "required": ["center", "size"],
+                "required": ["center", "extents"],
                 "properties": {
                     "center": { "$ref": "#/definitions/UnityObjects/Vector3" },
-                    "size": { "$ref": "#/definitions/UnityObjects/Vector3" }
+                    "extents": { "$ref": "#/definitions/UnityObjects/Vector3" }
                 }
             }
         },


### PR DESCRIPTION
Use extents instead of size for Bounds representation in state to be compatible with Engine code.