### PR TITLE
Volume Opacity Scalar Variable Input 

### DIFF
--- a/ABRSchema_0-2-0.json
+++ b/ABRSchema_0-2-0.json
@@ -777,6 +777,14 @@
                                 "inputValue": { "$ref": "#/definitions/InputStringTypes/UUID" }
                         }
                     },
+                    "Opacity Variable": {
+                        "properties": {
+                                "inputType": { "const": "IVLab.ABREngine.ScalarDataVariable" },
+                                "parameterName": { "const": "Color" },
+                                "inputGenre": { "const": "Variable" },
+                                "inputValue": { "$ref": "#/definitions/InputStringTypes/DataPath" }
+                        }
+                    },
                     "Opacitymap": {
                         "description": "Defines the opacity of the volume at control points along its scalar range.",
                         "properties": {

--- a/ABRSchema_0-2-0.json
+++ b/ABRSchema_0-2-0.json
@@ -795,7 +795,7 @@
                                 "inputGenre": { "const": "Primitive" }
                         }
                     },
-                    "Volume Opacity Multiplier": {
+                    "Volume Opacity": {
                         "description": "How opaque the volume should appear. 0% - fully transparent; 100% - fully opaque.",
                         "properties": {
                                 "inputType": { "const": "IVLab.ABREngine.PercentPrimitive" },


### PR DESCRIPTION
[Partner ABREngine PR](https://github.umn.edu/ivlab-cs/ABREngine-UnityPackage/pull/47)
- Adds support for scalar variable input tied to volume opacity. 
- Renames "Volume Opacity Multiplier" to "Volume Opacity" so that text is no longer cut-off on the volume impression.